### PR TITLE
Order monit processes after the monit daemon

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,5 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.pattern = 'spec/*/*_spec.rb'
 end
+
+task :default => :spec

--- a/manifests/process.pp
+++ b/manifests/process.pp
@@ -16,7 +16,8 @@ define monit::process(
 
   service {$name:
     ensure   => $ensure,
-    provider => monit,
+    provider => 'monit',
+    require  => Service['monit'],
   }
 
 }

--- a/spec/defines/process_spec.rb
+++ b/spec/defines/process_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe 'monit::process' do
+  let(:title) { 'testprocess' }
+
+  let(:params) { {
+    :start_command => 'start',
+    :stop_command => 'stop',
+    :pidfile => 'pidfile',
+  } }
+
+  it 'declares a monit service' do
+    should contain_service(title).with_provider('monit')
+  end
+
+  describe 'monit service' do
+    it 'requires monit to be installed' do
+      should contain_service(title).that_requires('Service[monit]')
+    end
+  end
+end


### PR DESCRIPTION
On the first run, puppet will fail to start a monit process sometimes, if the
resources happen to be evaluated in the wrong order, because monit (the daemon)
isn't yet running.
