### PR TITLE
Do not attempt to configure monit before installing it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+.bundle/

--- a/manifests/process.pp
+++ b/manifests/process.pp
@@ -12,6 +12,8 @@ define monit::process(
     group   => 'root',
     content => template('monit/process.erb'),
     notify  => Class['monit::service'],
+    require => Class['monit::package'],
+    before  => Service[$name],
   }
 
   service {$name:

--- a/spec/defines/process_spec.rb
+++ b/spec/defines/process_spec.rb
@@ -9,12 +9,36 @@ describe 'monit::process' do
     :pidfile => 'pidfile',
   } }
 
-  it 'declares a monit service' do
-    should contain_service(title).with_provider('monit')
+  describe 'configuration file' do
+    let(:filename) { "/etc/monit/conf.d/#{title}" }
+
+    it 'is declared' do
+      should contain_file(filename)
+    end
+
+    it 'requires monit to be installed' do
+      # can't very well create the configuration file when the directory that
+      # should contain it doesn't exist because monit has not yet been
+      # installed.
+      should contain_file(filename).that_requires('Class[monit::package]')
+    end
+
+    it 'comes before the monit service' do
+      should contain_file(filename).that_comes_before("Service[#{title}]")
+    end
+
+    it 'notifies the monit daemon' do
+      should contain_file(filename).that_notifies("Class[monit::service]")
+    end
   end
 
+
   describe 'monit service' do
-    it 'requires monit to be installed' do
+    it 'is declared' do
+      should contain_service(title).with_provider('monit')
+    end
+
+    it 'requires the monit daemon' do
       should contain_service(title).that_requires('Service[monit]')
     end
   end


### PR DESCRIPTION
The monit package provides /etc/monit/conf.d, which must exist before trying to make a configuration file there.
