### PR TITLE
Improvements for monit

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,9 +1,22 @@
-class monit::config(
-  $interval = 120,
-  $httpd    = false,
+# Configure monit daemon
+#
+# [use_syslog] - Use syslog for monit logs. Optional. Default false.
+# [interval] - Status polling interval for monit. Optional. Default 30 sec.
+#
+class monit::config (
+  $use_syslog = false,
+  $interval   = 30,
+  $httpd      = false,
 ) {
 
-  file {'/etc/monit/monitrc':
+include monit::params
+$config = $::monit::params::config
+$included = $::monit::params::included
+$idfile = $::monit::params::idfile
+$statefile = $::monit::params::statefile
+$basedir = $::monit::params::basedir
+
+  file { $config :
     ensure  => present,
     owner   => 'root',
     group   => 'root',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,22 @@
+#
+class monit::params {
+  case $::osfamily {
+    'RedHat' : {
+      $idfile     = '/var/.monit.id'
+      $statefile  = '/var/.monit.state'
+      $basedir    = '/var/monit'
+      $included   = '/etc/monit.d'
+      $config     = '/etc/monit.conf'
+    }
+    'Debian' : {
+      $idfile     = '/var/lib/monit/id'
+      $statefile  = '/var/lib/monit/state'
+      $basedir    = '/var/lib/monit/events'
+      $included   = '/etc/monit/conf.d'
+      $config     = '/etc/monit/monitrc'
+    }
+    default  : {
+      fail("Unsupported osfamily: ${osfamily} for os ${operatingsystem}")
+    }
+  }
+}

--- a/manifests/process.pp
+++ b/manifests/process.pp
@@ -18,7 +18,7 @@ define monit::process(
   $stop_command
 ) {
 
-  #include monit
+  include monit
   $servicep = $::monit::params::servicep
   $included = $::monit::params::included
 

--- a/manifests/process.pp
+++ b/manifests/process.pp
@@ -1,25 +1,48 @@
+# Configures monit watchdog for given process name.
+#
+# [matching] - Match process by string. Optional. Default the same as process name.
+# [pidfile]  - Match process by its pidfile. Optional. Default ''.
+# [stop_command] - How monit should issue stop command for process. Mandatory.
+# [start_command] - How monit should issue start command for process. Mandatory.
+# [timeout] - Configure monit to wait for the start/stop action to finish by checking the
+#   process table. Optional. Default 30 sec.
+#
+# Note, if service is already defined in catalog, it would be redefined to monit provider.
+#
 define monit::process(
-  $ensure="running",
-  $pidfile = '',
+  $matching = $name,
+  $ensure   = 'running',
+  $pidfile  = '',
+  $timeout  = 30,
   $start_command,
-  $stop_command) {
+  $stop_command
+) {
 
   #include monit
+  $servicep = $::monit::params::servicep
+  $included = $::monit::params::included
 
-  file {"/etc/monit/conf.d/${name}":
+  file { "${included}/${name}" :
     ensure  => present,
     owner   => 'root',
     group   => 'root',
     content => template('monit/process.erb'),
     notify  => Class['monit::service'],
     require => Class['monit::package'],
-    before  => Service[$name],
   }
 
-  service {$name:
-    ensure   => $ensure,
-    provider => 'monit',
-    require  => Service['monit'],
+  if defined(Service[$name]) {
+    Service <| title == $name |> {
+      ensure   => $ensure,
+      provider => 'monit',
+      require  => [ Service['monit'], File["${included}/${name}"], ],
+    }
+  } else {
+    service {$name:
+      ensure   => $ensure,
+      provider => 'monit',
+      require  => [ Service['monit'], File["${included}/${name}"], ],
+    }
   }
 
 }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -1,5 +1,13 @@
 require 'spec_helper'
 
 describe 'monit::config' do
-  it { should contain_file('/etc/monit/monitrc') }
+  describe 'when debian' do
+    let(:facts) { { :osfamily => 'debian' } }
+    it { should contain_file('/etc/monit/monitrc') }
+  end
+
+  describe 'when redhat' do
+    let(:facts) { { :osfamily => 'redhat' } }
+    it { should contain_file('/etc/monit.conf') }
+  end
 end

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -1,5 +1,13 @@
 require 'spec_helper'
 
 describe 'monit::package' do
-  it { should contain_package('monit') }
+  describe 'when debian' do
+    let(:facts) { { :osfamily => 'debian' } }
+    it { should contain_package('monit') }
+  end
+
+  describe 'when redhat' do
+    let(:facts) { { :osfamily => 'redhat' } }
+    it { should contain_package('monit') }
+  end
 end

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -1,5 +1,13 @@
 require 'spec_helper'
 
 describe 'monit::service' do
-  it { should contain_service('monit') }
+  describe 'when debian' do
+    let(:facts) { { :osfamily => 'debian' } }
+    it { should contain_service('monit') }
+  end
+
+  describe 'when redhat' do
+    let(:facts) { { :osfamily => 'redhat' } }
+    it { should contain_service('monit') }
+  end
 end

--- a/spec/defines/process_spec.rb
+++ b/spec/defines/process_spec.rb
@@ -9,8 +9,35 @@ describe 'monit::process' do
     :pidfile => 'pidfile',
   } }
 
-  describe 'configuration file' do
-    let(:filename) { "/etc/monit/conf.d/#{title}" }
+  let(:facts) { { :osfamily => 'debian' } }
+  let(:filename) { "/etc/monit/conf.d/#{title}" }
+
+  describe 'configuration file debian' do
+
+    it 'is declared' do
+      should contain_file(filename)
+    end
+
+    it 'requires monit to be installed' do
+      # can't very well create the configuration file when the directory that
+      # should contain it doesn't exist because monit has not yet been
+      # installed.
+      should contain_file(filename).that_requires('Class[monit::package]')
+    end
+
+    it 'comes before the monit service' do
+      should contain_file(filename).that_comes_before("Service[#{title}]")
+    end
+
+    it 'notifies the monit daemon' do
+      should contain_file(filename).that_notifies("Class[monit::service]")
+    end
+  end
+
+  let(:facts) { { :osfamily => 'redhat' } }
+  let(:filename) { "/etc/monit.d/#{title}" }
+
+  describe 'configuration file redhat' do
 
     it 'is declared' do
       should contain_file(filename)

--- a/spec/defines/process_spec.rb
+++ b/spec/defines/process_spec.rb
@@ -9,7 +9,7 @@ describe 'monit::process' do
     :pidfile => 'pidfile',
   } }
 
-  let(:facts) { { :osfamily => 'debian' } }
+  let(:facts) { { :osfamily => 'Debian' } }
   let(:filename) { "/etc/monit/conf.d/#{title}" }
 
   describe 'configuration file debian' do
@@ -34,7 +34,7 @@ describe 'monit::process' do
     end
   end
 
-  let(:facts) { { :osfamily => 'redhat' } }
+  let(:facts) { { :osfamily => 'RedHat' } }
   let(:filename) { "/etc/monit.d/#{title}" }
 
   describe 'configuration file redhat' do

--- a/templates/monitrc.erb
+++ b/templates/monitrc.erb
@@ -5,8 +5,8 @@
 ## Comments begin with a '#' and extend through the end of the line. Keywords
 ## are case insensitive. All path's MUST BE FULLY QUALIFIED, starting with '/'.
 ##
-## Below you will find examples of some frequently used statements. For 
-## information about the control file and a complete list of statements and 
+## Below you will find examples of some frequently used statements. For
+## information about the control file and a complete list of statements and
 ## options, please have a look in the Monit manual.
 ##
 ##
@@ -16,25 +16,27 @@
 ##
 ## Start Monit in the background (run as a daemon):
 #
-  set daemon <%= @interval %>            # check services at 2-minute intervals
-#   with start delay 240    # optional: delay the first check by 4-minutes (by 
+  set daemon <%= @interval %>             # check services at <%= @interval %>-sec intervals
+#   with start delay 240    # optional: delay the first check by 4-minutes (by
 #                           # default Monit check immediately after Monit start)
 #
 #
 ## Set syslog logging with the 'daemon' facility. If the FACILITY option is
-## omitted, Monit will use 'user' facility by default. If you want to log to 
+## omitted, Monit will use 'user' facility by default. If you want to log to
 ## a standalone log file instead, specify the full path to the log file
 #
-# set logfile syslog facility log_daemon                       
+<%- if @use_syslog %>
+  set logfile syslog facility log_daemon
+<%- else %>
   set logfile /var/log/monit.log
+<%- end %>
 #
 #
 ## Set the location of the Monit id file which stores the unique id for the
-## Monit instance. The id is generated and stored on first Monit start. By 
+## Monit instance. The id is generated and stored on first Monit start. By
 ## default the file is placed in $HOME/.monit.id.
 #
-# set idfile /var/.monit.id
-  set idfile /var/lib/monit/id
+  set idfile <%= @idfile %>
 #
 ## Set the location of the Monit state file which saves monitoring states
 ## on each cycle. By default the file is placed in $HOME/.monit.state. If
@@ -42,11 +44,11 @@
 ## the monitoring state across reboots. If it is on temporary filesystem, the
 ## state will be lost on reboot which may be convenient in some situations.
 #
-  set statefile /var/lib/monit/state
+  set statefile <%= @statefile %>
 #
-## Set the list of mail servers for alert delivery. Multiple servers may be 
-## specified using a comma separator. If the first mail server fails, Monit 
-# will use the second mail server in the list and so on. By default Monit uses 
+## Set the list of mail servers for alert delivery. Multiple servers may be
+## specified using a comma separator. If the first mail server fails, Monit
+# will use the second mail server in the list and so on. By default Monit uses
 # port 25 - it is possible to override this with the PORT option.
 #
 # set mailserver mail.bar.baz,               # primary mailserver
@@ -54,23 +56,23 @@
 #                localhost                   # fallback relay
 #
 #
-## By default Monit will drop alert events if no mail servers are available. 
-## If you want to keep the alerts for later delivery retry, you can use the 
-## EVENTQUEUE statement. The base directory where undelivered alerts will be 
+## By default Monit will drop alert events if no mail servers are available.
+## If you want to keep the alerts for later delivery retry, you can use the
+## EVENTQUEUE statement. The base directory where undelivered alerts will be
 ## stored is specified by the BASEDIR option. You can limit the maximal queue
-## size using the SLOTS option (if omitted, the queue is limited by space 
+## size using the SLOTS option (if omitted, the queue is limited by space
 ## available in the back end filesystem).
 #
   set eventqueue
-      basedir /var/lib/monit/events # set the base directory where events will be stored
+      basedir <%= @basedir %> # set the base directory where events will be stored
       slots 100                     # optionally limit the queue size
 #
 #
-## Send status and events to M/Monit (for more informations about M/Monit 
-## see http://mmonit.com/). By default Monit registers credentials with 
+## Send status and events to M/Monit (for more informations about M/Monit
+## see http://mmonit.com/). By default Monit registers credentials with
 ## M/Monit so M/Monit can smoothly communicate back to Monit and you don't
 ## have to register Monit credentials manually in M/Monit. It is possible to
-## disable credential registration using the commented out option below. 
+## disable credential registration using the commented out option below.
 ## Though, if safety is a concern we recommend instead using https when
 ## communicating with M/Monit and send credentials encrypted.
 #
@@ -102,18 +104,18 @@
 # set mail-format { from: monit@foo.bar }
 #
 #
-## You can set alert recipients whom will receive alerts if/when a 
-## service defined in this file has errors. Alerts may be restricted on 
-## events by using a filter as in the second example below. 
+## You can set alert recipients whom will receive alerts if/when a
+## service defined in this file has errors. Alerts may be restricted on
+## events by using a filter as in the second example below.
 #
 # set alert sysadm@foo.bar                       # receive all alerts
 # set alert manager@foo.bar only on { timeout }  # receive just service-
 #                                                # timeout alert
 #
 #
-## Monit has an embedded web server which can be used to view status of 
+## Monit has an embedded web server which can be used to view status of
 ## services monitored and manage services from a web interface. See the
-## Monit Wiki if you want to enable SSL for the web server. 
+## Monit Wiki if you want to enable SSL for the web server.
 #
 <% if @httpd -%>
   set httpd port 2812 and
@@ -148,15 +150,15 @@
 #    if cpu usage (system) > 30% then alert
 #    if cpu usage (wait) > 20% then alert
 #
-#    
+#
 ## Check if a file exists, checksum, permissions, uid and gid. In addition
-## to alert recipients in the global section, customized alert can be sent to 
-## additional recipients by specifying a local alert handler. The service may 
+## to alert recipients in the global section, customized alert can be sent to
+## additional recipients by specifying a local alert handler. The service may
 ## be grouped using the GROUP option. More than one group can be specified by
 ## repeating the 'group name' statement.
-#    
+#
 #  check file apache_bin with path /usr/local/apache/bin/httpd
-#    if failed checksum and 
+#    if failed checksum and
 #       expect the sum 8f7f419955cefa0b33a2ba316cba3659 then unmonitor
 #    if failed permission 755 then unmonitor
 #    if failed uid root then unmonitor
@@ -166,15 +168,15 @@
 #        } with the mail-format { subject: Alarm! }
 #    group server
 #
-#    
+#
 ## Check that a process is running, in this case Apache, and that it respond
 ## to HTTP and HTTPS requests. Check its resource usage such as cpu and memory,
-## and number of children. If the process is not running, Monit will restart 
-## it by default. In case the service is restarted very often and the 
+## and number of children. If the process is not running, Monit will restart
+## it by default. In case the service is restarted very often and the
 ## problem remains, it is possible to disable monitoring using the TIMEOUT
 ## statement. This service depends on another service (apache_bin) which
 ## is defined above.
-#    
+#
 #  check process apache with pidfile /usr/local/apache/logs/httpd.pid
 #    start program = "/etc/init.d/httpd start" with timeout 60 seconds
 #    stop program  = "/etc/init.d/httpd stop"
@@ -183,7 +185,7 @@
 #    if totalmem > 200.0 MB for 5 cycles then restart
 #    if children > 250 then restart
 #    if loadavg(5min) greater than 10 for 8 cycles then stop
-#    if failed host www.tildeslash.com port 80 protocol http 
+#    if failed host www.tildeslash.com port 80 protocol http
 #       and request "/somefile.html"
 #       then restart
 #    if failed port 443 type tcpssl protocol http
@@ -192,8 +194,8 @@
 #    if 3 restarts within 5 cycles then timeout
 #    depends on apache_bin
 #    group server
-#    
-#    
+#
+#
 ## Check filesystem permissions, uid, gid, space and inode usage. Other services,
 ## such as databases, may depend on this resource and an automatically graceful
 ## stop may be cascaded to them before the filesystem will become full and data
@@ -212,7 +214,7 @@
 #    group server
 #
 #
-## Check a file's timestamp. In this example, we test if a file is older 
+## Check a file's timestamp. In this example, we test if a file is older
 ## than 15 minutes and assume something is wrong if its not updated. Also,
 ## if the file size exceed a given limit, execute a script
 #
@@ -224,8 +226,8 @@
 #    if size > 100 MB then exec "/my/cleanup/script" as uid dba and gid dba
 #
 #
-## Check directory permission, uid and gid.  An event is triggered if the 
-## directory does not belong to the user with uid 0 and gid 0.  In addition, 
+## Check directory permission, uid and gid.  An event is triggered if the
+## directory does not belong to the user with uid 0 and gid 0.  In addition,
 ## the permissions have to match the octal description of 755 (see chmod(1)).
 #
 #  check directory bin with path /bin
@@ -234,8 +236,8 @@
 #    if failed gid 0 then unmonitor
 #
 #
-## Check a remote host availability by issuing a ping test and check the 
-## content of a response from a web server. Up to three pings are sent and 
+## Check a remote host availability by issuing a ping test and check the
+## content of a response from a web server. Up to three pings are sent and
 ## connection to a port and an application level network check is performed.
 #
 #  check host myserver with address 192.168.1.1
@@ -253,5 +255,5 @@
 ## It is possible to include additional configuration parts from other files or
 ## directories.
 #
-   include /etc/monit/conf.d/*
+   include <%= @included %>/*
 #

--- a/templates/process.erb
+++ b/templates/process.erb
@@ -1,3 +1,7 @@
+<%- if @pidfile %>
 check process <%= @name %> with pidfile <%= @pidfile %>
-  start program = "<%= @start_command %>" with timeout 60 seconds
+<%- else %>
+check process <%= @name %> matching "<%= @matching %>"
+<%- end %>
+  start program = "<%= @start_command %>" with timeout <%= @timeout %> seconds
   stop program  = "<%= @stop_command %>"


### PR DESCRIPTION
* Lower daemon polling interval from 120 to 30 sec
* Add timeout for start/stop actions
* Add pidless services tracking as well
* Add params for Redhat/Centos support
* Make config template params based
* Add syslog support
* Redefine service's provider to monit, if already
  in catalog
* Adjust rspecs
* Add docs

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>